### PR TITLE
Add support for twitch logins with underscores (_)

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const sha256HashMetadata = '226edb3e692509f727fd56821f5653c05740242c82b0388883e0
 
 const argv = yargs(hideBin(process.argv)).argv
 
-const twitchVideoRegex = /^https:\/\/\w+.cloudfront.net\/[a-z0-9]+_([a-z0-9]+)_[0-9]+_[0-9]+/;
+const twitchVideoRegex = /^https:\/\/\w+.cloudfront.net\/[a-z0-9]+_([_a-z0-9]+)_[0-9]+_[0-9]+/;
 const getChannelLogin = (videoURL) => videoURL.match(twitchVideoRegex)[1];
 const getIndexURL = (videoURL) => videoURL.match(twitchVideoRegex)[0] + '/chunked/index-dvr.m3u8';
 


### PR DESCRIPTION
I had an issue when downloading video from [itmo_fitip](https://www.twitch.tv/itmo_fitip) channel.
So I found out that logins can contain underscores.